### PR TITLE
Use singular in plugin option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,39 +2,43 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     name: Build and test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: [24, 25, 26]
+        elixir: [1.12, 1.14]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-      with:
-        elixir-version: '1.12.3' # Define the elixir version [required]
-        otp-version: '24.1' # Define the OTP version [required]
+      - uses: actions/checkout@v3
 
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        version: "3.17.3"
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.otp}} # Define the OTP version [required]
 
-    - name: Restore dependencies cache
-      uses: actions/cache@v3
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
-    - name: Install dependencies
-      run: mix deps.get
-    - name: Run tests
-      run: mix test
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "3.17.3"
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Run tests
+        run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [24, 25, 26]
-        elixir: [1.12, 1.14]
+        otp: [24]
+        elixir: [1.12]
 
     steps:
       - uses: actions/checkout@v3

--- a/lib/mix/protobuf.generate.ex
+++ b/lib/mix/protobuf.generate.ex
@@ -104,10 +104,10 @@ defmodule Mix.Tasks.Protobuf.Generate do
 
     files = normalize_import_paths(files, imports, [])
 
-    Google.Protobuf.Compiler.CodeGeneratorRequest.new(
+    %Google.Protobuf.Compiler.CodeGeneratorRequest{
       file_to_generate: files,
       proto_file: file_descriptors
-    )
+    }
   end
 
   defp generate(ctx, request) do
@@ -126,11 +126,10 @@ defmodule Mix.Tasks.Protobuf.Generate do
         CodeGen.generate(ctx, desc, plugins)
       end)
 
-    response =
-      Google.Protobuf.Compiler.CodeGeneratorResponse.new(
-        file: files,
-        supported_features: Protobuf.Protoc.CLI.supported_features()
-      )
+    response = %Google.Protobuf.Compiler.CodeGeneratorResponse{
+      file: files,
+      supported_features: Protobuf.Protoc.CLI.supported_features()
+    }
 
     response
   end

--- a/lib/mix/protobuf.generate.ex
+++ b/lib/mix/protobuf.generate.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Protobuf.Generate do
   * `--generate-descriptors` - Includes raw descriptors in the generated modules
   * `--one-file-per-module` - Changes the way files are generated into directories. This option creates a file for each generated Elixir module.
   * `--include-documentation` - Controls visibility of documentation of the generated modules. Setting `true` will not  have `@moduleoc false`
-  * `--plugins` - If you write services in protobuf, you can generate gRPC code by passing `--plugins=grpc`.
+  * `--plugin` - If you write services in protobuf, you can generate gRPC code by passing `--plugin=grpc`.
 
   ## Examples
 
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Protobuf.Generate do
         --include-path=deps/googleapis \
         --generate-descriptors=true \
         --output-path=./lib \
-        --plugins=ProtobufGenerate.Plugins.GRPC
+        --plugin=ProtobufGenerate.Plugins.GRPC
         google/api/annotations.proto google/api/http.proto helloworld.proto
 
   """
@@ -49,14 +49,14 @@ defmodule Mix.Tasks.Protobuf.Generate do
     transform_module: :string,
     include_docs: :boolean,
     one_file_per_module: :boolean,
-    plugins: :keep
+    plugin: :keep
   ]
 
   @impl Mix.Task
   @spec run(any) :: any
   def run(args) do
     {opts, files} = OptionParser.parse!(args, strict: @switches)
-    {plugins, opts} = pop_values(opts, :plugins)
+    {plugins, opts} = pop_values(opts, :plugin)
     {imports, opts} = pop_values(opts, :include_path)
 
     transform_module =

--- a/lib/protobuf_generate/code_gen.ex
+++ b/lib/protobuf_generate/code_gen.ex
@@ -54,10 +54,10 @@ defmodule ProtobufGenerate.CodeGen do
     for {mod_name, content} <- module_definitions do
       file_name = Macro.underscore(mod_name) <> ".pb.ex"
 
-      Google.Protobuf.Compiler.CodeGeneratorResponse.File.new(
+      %Google.Protobuf.Compiler.CodeGeneratorResponse.File{
         name: file_name,
         content: content
-      )
+      }
     end
   end
 
@@ -71,10 +71,10 @@ defmodule ProtobufGenerate.CodeGen do
       |> Util.format()
 
     [
-      Google.Protobuf.Compiler.CodeGeneratorResponse.File.new(
+      %Google.Protobuf.Compiler.CodeGeneratorResponse.File{
         name: file_name,
         content: content
-      )
+      }
     ]
   end
 

--- a/test/mix/tasks/protobuf.generate_test.exs
+++ b/test/mix/tasks/protobuf.generate_test.exs
@@ -197,7 +197,7 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
       "--include-path=#{tmp_dir}",
       "--include-path=#{Mix.Project.deps_paths().google_protobuf}/src",
       "--output-path=#{tmp_dir}",
-      "--plugins=ProtobufGenerate.Plugins.GRPC",
+      "--plugin=ProtobufGenerate.Plugins.GRPC",
       proto_path
     ])
 


### PR DESCRIPTION
The idea is that if you can pass multiple plugins and it's not a list passed once, then you should call `--plugin` repeatedly. It's just a semantic change.

This PR is based on the same branch as PR #1