### PR TITLE
Use temporary directory instead of build_path

### DIFF
--- a/lib/protobuf_generate/protoc.ex
+++ b/lib/protobuf_generate/protoc.ex
@@ -15,7 +15,7 @@ defmodule ProtobufGenerate.Protoc do
 
   defp run_protoc(proto_files, args) do
     outfile_name = "protobuf_#{random_string()}"
-    outfile_path = Path.join([Mix.Project.build_path(), outfile_name])
+    outfile_path = Path.join([System.tmp_dir!(), outfile_name])
 
     cmd_args =
       ["--include_imports", "--include_source_info", "-o", outfile_path] ++ args ++ proto_files


### PR DESCRIPTION
Hi @drowzy I fell into an atypical situation where I'm running protobuf-generate inside a container and I received the undefined error for Mix.Project.build_path/0. This pr solves this problem by using a temporary directory to generate the protobufs.