### PR TITLE
Resolve warning for missing assign in GRPCWithOptions plugin

### DIFF
--- a/lib/protobuf_generate/plugins/grpc_with_options.ex
+++ b/lib/protobuf_generate/plugins/grpc_with_options.ex
@@ -71,7 +71,8 @@ defmodule ProtobufGenerate.Plugins.GRPCWithOptions do
          service_name: name,
          methods: methods,
          descriptor_fun_body: descriptor_fun_body,
-         version: Util.version()
+         version: Util.version(),
+         module_doc?: ctx.include_docs?
        ]}
     end
   end


### PR DESCRIPTION
Hi there 👋🏼 

When using the `GRPCWithOptions` plugin, a warning is emitted (twice):

```
warning: assign @module_doc? not available in EEx template. Please ensure all assigns are given as options. Available assigns: [:module, :service_name, :methods, :descriptor_fun_body, :version]
  (eex 1.17.3) lib/eex/engine.ex:140: EEx.Engine.fetch_assign!/2
  (elixir 1.17.3) src/elixir.erl:386: :elixir.eval_external_handler/3
  (stdlib 6.1.2) erl_eval.erl:904: :erl_eval.do_apply/7
  (stdlib 6.1.2) erl_eval.erl:479: :erl_eval.expr/6
  (stdlib 6.1.2) erl_eval.erl:648: :erl_eval.expr/6
  (stdlib 6.1.2) erl_eval.erl:271: :erl_eval.exprs/6
```

This PR resolves the issue by creating a `@module_doc?` assign similar to the one available in the `GRPC` plugin.

❤️ 