### PR TITLE
Add Field Documentation for Messages

### DIFF
--- a/lib/protobuf_generate/plugins/grpc_with_options.ex
+++ b/lib/protobuf_generate/plugins/grpc_with_options.ex
@@ -13,9 +13,7 @@ defmodule ProtobufGenerate.Plugins.GRPCWithOptions do
   def template do
     """
     defmodule <%= @module %>.Service do
-      <%= unless @module_doc? do %>
       @moduledoc false
-      <% end %>
       use GRPC.Service, name: <%= inspect(@service_name) %>, protoc_gen_elixir_version: "<%= @version %>"
 
       <%= if @descriptor_fun_body do %>
@@ -31,9 +29,7 @@ defmodule ProtobufGenerate.Plugins.GRPCWithOptions do
     end
 
     defmodule <%= @module %>.Stub do
-      <%= unless @module_doc? do %>
       @moduledoc false
-      <% end %>
       use GRPC.Stub, service: <%= @module %>.Service
     end
     """

--- a/lib/protobuf_generate/plugins/message.ex
+++ b/lib/protobuf_generate/plugins/message.ex
@@ -382,14 +382,15 @@ defmodule ProtobufGenerate.Plugins.Message do
 
     if comments != "" do
       fields =
-        Enum.sort_by(desc.field, fn field -> field.name end)
-        |> Enum.with_index(fn field, index ->
+        Enum.with_index(desc.field, fn field, index ->
           ctx = Context.append_comment_path(ctx, "2.#{index}")
-          field_comment(ctx, field)
+          {field.name, field_comment(ctx, field)}
         end)
+        |> Enum.sort_by(fn {name, _comment} -> name end)
+        |> Enum.map(fn {_name, comment} -> comment end)
 
       field_rows =
-        Enum.map(fields, fn {comment, _name} -> comment end)
+        Enum.map(fields, fn {row, _additional} -> row end)
         |> Enum.join("\n")
 
       additional_notes =

--- a/test/mix/tasks/protobuf.generate_test.exs
+++ b/test/mix/tasks/protobuf.generate_test.exs
@@ -312,6 +312,7 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
       ])
 
       file = File.read!("#{tmp_dir}/user.pb.ex")
+      IO.puts(file)
 
       assert file =~ """
              defmodule Foo.UserWithDocs do
@@ -325,11 +326,39 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
 
                ## Fields
 
-               | # | Name | Type | Notes |
-               |---|---|---|---|
-               | 1 | `email` | `:string` | Single-line field comment |
-               | 2 | `active` | `:bool` | Multi-line field comment  With a second line that continues onto a third. |
-               | 3 | `created_at` | `Foo.SubMessage` |   |
+               <table>
+                 <thead>
+                   <tr>
+                     <th>#</th>
+                     <th>Name</th>
+                     <th>Type</th>
+                     <th>Notes</th>
+                   </tr>
+                 </thead>
+                 <tbody>
+                   <tr>
+                 <td>2</td>
+                 <td><code style="font-weight: bold">active</code></td>
+                 <td><code>bool</code></td>
+                 <td>Multi-line field comment<br> With a second line that continues onto
+                a third.</td>
+               </tr>
+               <tr>
+                 <td>3</td>
+                 <td><code style="font-weight: bold">created_at</code></td>
+                 <td><code>Foo.SubMessage</code></td>
+                 <td></td>
+               </tr>
+               <tr>
+                 <td>1</td>
+                 <td><code style="font-weight: bold">email</code></td>
+                 <td><code>string</code></td>
+                 <td>Single-line field comment</td>
+               </tr>
+
+                 </tbody>
+               </table>
+
                \"\"\"
              """
     end

--- a/test/mix/tasks/protobuf.generate_test.exs
+++ b/test/mix/tasks/protobuf.generate_test.exs
@@ -340,13 +340,13 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
 
                | # | Name | Type | Notes |
                |---|------|------|-------|
-               | 2 | **`active`** | `bool` | Single-line field comment |
-               | 3 | **`created_at`** | `Foo.SubMessage` | Multi-line field comment |
-               | 1 | **`email`** | `string` |  |
+               | 2 | **`active`** | `bool` | Multi-line field comment |
+               | 3 | **`created_at`** | `Foo.SubMessage` |  |
+               | 1 | **`email`** | `string` | Single-line field comment |
 
                ### Additional Notes
 
-                 * `created_at` (`Foo.SubMessage`): Multi-line field comment
+                 * `active` (`bool`): Multi-line field comment
 
                     With a second line that _continues_ onto
                     a third.

--- a/test/mix/tasks/protobuf.generate_test.exs
+++ b/test/mix/tasks/protobuf.generate_test.exs
@@ -291,6 +291,12 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
         // With a second line that continues onto
         // a third.
         bool active = 2;
+
+        SubMessage created_at = 3;
+      }
+
+      message SubMessage {
+        int32 data = 1;
       }
       """)
 
@@ -316,6 +322,14 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
                third line.
 
                  This line has `indentation` and *styling*.
+
+               ## Fields
+
+               | # | Name | Type | Notes |
+               |---|---|---|---|
+               | 1 | `email` | `:string` | Single-line field comment |
+               | 2 | `active` | `:bool` | Multi-line field comment  With a second line that continues onto a third. |
+               | 3 | `created_at` | `Foo.SubMessage` |   |
                \"\"\"
              """
     end

--- a/test/mix/tasks/protobuf.generate_test.exs
+++ b/test/mix/tasks/protobuf.generate_test.exs
@@ -104,7 +104,7 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
                compile_file_and_clean_modules_on_exit("#{tmp_dir}/lowercase_enum.pb.ex")
     end
 
-    test "does not produce moduledoc", %{tmp_dir: tmp_dir, proto_path: proto_path} do
+    test "produces a moduledoc with generic message", %{tmp_dir: tmp_dir, proto_path: proto_path} do
       run([
         "--include-docs",
         "--include-path=#{tmp_dir}",
@@ -113,7 +113,20 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
       ])
 
       file = File.read!("#{tmp_dir}/user.pb.ex")
-      assert file =~ "defmodule Foo.User do\n  @moduledoc false\n  use Protobuf"
+
+      assert file =~ """
+             defmodule Foo.User do
+               @moduledoc \"\"\"
+               Automatically generated module for User
+
+               ## Fields
+
+               | # | Name | Type | Notes |
+               |---|------|------|-------|
+               | 1 | **`email`** | `string` |  |
+
+               \"\"\"
+             """
     end
   end
 

--- a/test/mix/tasks/protobuf.generate_test.exs
+++ b/test/mix/tasks/protobuf.generate_test.exs
@@ -288,7 +288,7 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
 
         // Multi-line field comment
         //
-        // With a second line that continues onto
+        // With a second line that _continues_ onto
         // a third.
         bool active = 2;
 
@@ -312,7 +312,6 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
       ])
 
       file = File.read!("#{tmp_dir}/user.pb.ex")
-      IO.puts(file)
 
       assert file =~ """
              defmodule Foo.UserWithDocs do
@@ -326,38 +325,18 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
 
                ## Fields
 
-               <table>
-                 <thead>
-                   <tr>
-                     <th>#</th>
-                     <th>Name</th>
-                     <th>Type</th>
-                     <th>Notes</th>
-                   </tr>
-                 </thead>
-                 <tbody>
-                   <tr>
-                 <td>2</td>
-                 <td><code style="font-weight: bold">active</code></td>
-                 <td><code>bool</code></td>
-                 <td>Multi-line field comment<br> With a second line that continues onto
-                a third.</td>
-               </tr>
-               <tr>
-                 <td>3</td>
-                 <td><code style="font-weight: bold">created_at</code></td>
-                 <td><code>Foo.SubMessage</code></td>
-                 <td></td>
-               </tr>
-               <tr>
-                 <td>1</td>
-                 <td><code style="font-weight: bold">email</code></td>
-                 <td><code>string</code></td>
-                 <td>Single-line field comment</td>
-               </tr>
+               | # | Name | Type | Notes |
+               |---|------|------|-------|
+               | 2 | **`active`** | `bool` | Single-line field comment |
+               | 3 | **`created_at`** | `Foo.SubMessage` | Multi-line field comment |
+               | 1 | **`email`** | `string` |  |
 
-                 </tbody>
-               </table>
+               ### Additional Notes
+
+                 * `created_at` (`Foo.SubMessage`): Multi-line field comment
+
+                    With a second line that _continues_ onto
+                    a third.
 
                \"\"\"
              """


### PR DESCRIPTION
Hello again 👋🏼 

This PR adds field documentation to the `@moduledoc` for modules generated from messages. The first line of the field documentation is included in a summary table, while additional lines (if any) are relegated to an "Additional Notes" section at the end. We do this because `ex_doc` does not support both markdown-formatted and multi-line strings in table cells.

Care is again taken to handle edge cases related to indentation.

Please let me know if you are still interested in these kinds of enhancements.