### PR TITLE
Fix relative path problems

### DIFF
--- a/lib/mix/protobuf.generate.ex
+++ b/lib/mix/protobuf.generate.ex
@@ -123,7 +123,17 @@ defmodule Mix.Tasks.Protobuf.Generate do
     files =
       Enum.flat_map(request.file_to_generate, fn file ->
         desc = Enum.find(request.proto_file, &(&1.name == file))
-        CodeGen.generate(ctx, desc, plugins)
+
+        if desc == nil do
+          IO.puts(
+            :stderr,
+            "Failed to locate the description for #{file}. Check include paths and paths to proto files."
+          )
+
+          []
+        else
+          CodeGen.generate(ctx, desc, plugins)
+        end
       end)
 
     response = %Google.Protobuf.Compiler.CodeGeneratorResponse{

--- a/lib/mix/protobuf.generate.ex
+++ b/lib/mix/protobuf.generate.ex
@@ -156,14 +156,15 @@ defmodule Mix.Tasks.Protobuf.Generate do
   defp normalize_import_paths([], _, acc), do: Enum.reverse(acc)
 
   defp normalize_import_paths([file | rest], imports, acc) do
-    file_path =
-      Enum.reduce_while(imports, file, fn i, file ->
-        relative_path = Path.relative_to(file, i)
+    {_, file_path} =
+      Enum.reduce_while(imports, {file, nil}, fn i, {filename, _found_path} ->
+        abs_path = Path.join(i, filename)
 
-        if relative_path == file do
-          {:cont, file}
+        if File.exists?(abs_path) do
+          {:halt, {filename, filename}}
         else
-          {:halt, relative_path}
+          relative_path = Path.relative_to(filename, i)
+          {:cont, {filename, relative_path}}
         end
       end)
 

--- a/test/mix/tasks/protobuf.generate_test.exs
+++ b/test/mix/tasks/protobuf.generate_test.exs
@@ -119,7 +119,8 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
 
   # Regression test for https://github.com/elixir-protobuf/protobuf/issues/242
   test "with external packages and the package_prefix option", %{tmp_dir: tmp_dir} do
-    proto_path = Path.join(tmp_dir, "timestamp_wrapper.proto")
+    proto_file = "timestamp_wrapper.proto"
+    proto_path = Path.join(tmp_dir, proto_file)
 
     File.write!(proto_path, """
     syntax = "proto3";
@@ -136,7 +137,7 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
       "--include-path=#{Mix.Project.deps_paths().google_protobuf}/src",
       "--output-path=#{tmp_dir}",
       "--package-prefix=my_type",
-      proto_path
+      proto_file
     ])
 
     assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/timestamp_wrapper.pb.ex")
@@ -146,7 +147,8 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
   end
 
   test "with grpc plugin", %{tmp_dir: tmp_dir} do
-    proto_path = Path.join(tmp_dir, "helloworld.proto")
+    proto_file = "helloworld.proto"
+    proto_path = Path.join(tmp_dir, proto_file)
 
     File.write!(proto_path, """
     syntax = "proto3";
@@ -180,7 +182,7 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
       "--include-path=#{Mix.Project.deps_paths().google_protobuf}/src",
       "--output-path=#{tmp_dir}",
       "--plugin=ProtobufGenerate.Plugins.GRPC",
-      proto_path
+      proto_file
     ])
 
     assert [_, _, _, service, stub] =
@@ -194,7 +196,7 @@ defmodule Mix.Tasks.Protobuf.GenerateTest do
   @tag :skip
   test "with grpc options plugin", %{tmp_dir: tmp_dir} do
     # proto_path = Path.join(tmp_dir, "helloworld_options.proto")
-    proto_path = Path.join(tmp_dir, "helloworld_options.proto")
+    proto_path = "helloworld_options.proto"
     paths = ["google/api/annotations.proto", "google/api/http.proto", "helloworld_options.proto"]
 
     File.write!(proto_path, """


### PR DESCRIPTION
See issue https://github.com/drowzy/protobuf_generate/issues/5

This resolve the problem by not turning paths that exist within the include dirs into relative paths.

With the following command:

`
mix protobuf.generate \
  --include-path=deps/grpc/deps/googleapis \
  --include-path=grpc_service_definitions \
  --generate-descriptors=true \
  --output-path=./tmp \
  --plugin=ProtobufGenerate.Plugins.GRPCWithOptions \
  google/api/annotations.proto \
  google/api/http.proto \
  discovery.proto
`

And `discovery.proto` in `./grpc_service_definitions` relative to the project root, this will fail with a message about `nil` being passed as the second param to `ProtobufGenerate.CodeGen.generate/3`. The problem is that the `.proto` files passed are all actually under the `include_path`s given.

However, since some are in subdirectories and there are multiple include paths provided, they will all be turned into unfindable relative paths.

Simply checking that they exist under one of the include paths resolves this issue and generates correct proto files.