### PR TITLE
Handle RPC methods with missing options

### DIFF
--- a/lib/protobuf_generate/plugins/grpc_with_options.ex
+++ b/lib/protobuf_generate/plugins/grpc_with_options.ex
@@ -76,6 +76,10 @@ defmodule ProtobufGenerate.Plugins.GRPCWithOptions do
   defp service_arg(type, _streaming? = true), do: "stream(#{type})"
   defp service_arg(type, _streaming?), do: type
 
+  defp opts(nil) do
+    %{}
+  end
+
   defp opts(%Google.Protobuf.MethodOptions{__pb_extensions__: extensions})
        when extensions == %{} do
     %{}


### PR DESCRIPTION
Given the following file `priv/test.proto`:

```protobuf
import "google/api/annotations.proto";

service TestService {
  rpc Get(TestServiceGetRequest)
    returns (stream TestServiceGetResponse) {
    option (google.api.http) = {
      post: "/v1/test"
      body: "*"
    };
  };

  rpc GetOther(TestServiceGetOtherRequest)
    returns (stream TestServiceGetOtherResponse);
}

message TestServiceGetRequest {}
message TestServiceGetResponse {}

message TestServiceGetOtherRequest {}
message TestServiceGetOtherResponse {}
```

This command will fail as of 0.2.0:

```
mix protobuf.generate \
  --generate-descriptors=false \
  --include-path=deps/googleapis \
  --include-path=priv
  --plugin=ProtobufGenerate.Plugins.GRPCWithOptions
  --output-path=tmp \
  test.proto
```

Giving:

```
** (FunctionClauseError) no function clause matching in ProtobufGenerate.Plugins.GRPCWithOptions.opts/1

    The following arguments were given to ProtobufGenerate.Plugins.GRPCWithOptions.opts/1:

        # 1
        nil

    Attempted function clauses (showing 2 out of 2):

        defp opts(%Google.Protobuf.MethodOptions{__pb_extensions__: extensions}) when extensions == %{}
        defp opts(%Google.Protobuf.MethodOptions{__pb_extensions__: extensions})

    (protobuf_generate 0.2.0) lib/protobuf_generate/plugins/grpc_with_options.ex:79: ProtobufGenerate.Plugins.GRPCWithOptions.opts/1
    (protobuf_generate 0.2.0) lib/protobuf_generate/plugins/grpc_with_options.ex:58: anonymous fn/2 in ProtobufGenerate.Plugins.GRPCWithOptions.generate/2
    (elixir 1.18.4) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.18.4) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (protobuf_generate 0.2.0) lib/protobuf_generate/plugins/grpc_with_options.ex:52: anonymous fn/3 in ProtobufGenerate.Plugins.GRPCWithOptions.generate/2
    (elixir 1.18.4) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (protobuf_generate 0.2.0) lib/protobuf_generate/code_gen.ex:24: anonymous fn/3 in ProtobufGenerate.CodeGen.generate/3
    (elixir 1.18.4) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
```

The command passes if the `GetOther` method is given an empty method options block:

```protobuf
rpc GetOther(TestServiceGetOtherRequest)
  returns (stream TestServiceGetOtherResponse) {};
```

It seems reasonable to me for a service definition to have some methods with options blocks and some without, so this PR modifies the `GRPCWithOptions` plugin to allow for missing options blocks.

This PR lets the command above succeed  given the original `priv/test.proto` file. The `tmp/test.pb.ex` file that results is:

```elixir
defmodule TestServiceGetRequest do
  @moduledoc false
  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
end

defmodule TestServiceGetResponse do
  @moduledoc false
  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
end

defmodule TestServiceGetOtherRequest do
  @moduledoc false
  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
end

defmodule TestServiceGetOtherResponse do
  @moduledoc false
  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
end

defmodule TestService.Service do
  @moduledoc false
  use GRPC.Service, name: "TestService", protoc_gen_elixir_version: "0.14.0"

  rpc(:Get, TestServiceGetRequest, stream(TestServiceGetResponse), %{})

  rpc(:GetOther, TestServiceGetOtherRequest, stream(TestServiceGetOtherResponse), %{})
end

defmodule TestService.Stub do
  @moduledoc false
  use GRPC.Stub, service: TestService.Service
end
```